### PR TITLE
WDP181202-4

### DIFF
--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -29,6 +29,20 @@
       left: 5%;
       right: 5%;
       bottom: 0%;
+      opacity: 0;
+    }
+  }
+
+  &:hover {
+    .buttons {
+      background-color: #2a2a2a;
+      color: #ffffff;
+      text-decoration: none;
+      opacity: 1;
+
+      &:not(.no-hover) {
+        background-color: $primary;
+      }
     }
   }
 


### PR DESCRIPTION
Issue: The "Quick view" and "Add to cart" buttons should only be visible on the hover of the entire product box. Then the price background should change.


Solution: Adding opacity to .buttons and hover with content on the .product-box in the _product-box.scss file.